### PR TITLE
Scst: A few things I had to fix to get the RA's working for me

### DIFF
--- a/heartbeat/SCSTLogicalUnit
+++ b/heartbeat/SCSTLogicalUnit
@@ -1018,7 +1018,7 @@ SCSTLogicalUnit_notify() {
             # Switch all new slave instances TPG to standby
             for node in $startit; do
                 # Do we have any master(s) at all and did the start happened locally?
-                if [ "$node" = "$HOSTNAME" ]; then
+                if [ "$node" == "$HOSTNAME" ]; then
                     # We are slave: be sure the master(s) TPG is also
                     # set to active (without luns) on this node.
                     # We rely on default standby state on creation.

--- a/heartbeat/SCSTLogicalUnit
+++ b/heartbeat/SCSTLogicalUnit
@@ -113,7 +113,7 @@ a Target, exported via a daemon that speaks a specific protocol.
 <shortdesc lang="en">Manages Logical Units (LUs) for SCST targets</shortdesc>
 
 <parameters>
-<parameter name="fabric" required="0" unique="1">
+<parameter name="fabric" required="0" unique="0">
 <longdesc lang="en">
 The SCST target supports several fabric types. Must be one of "iscsi" or
 "qla2x00t". If unspecified, "iscsi" is used.
@@ -122,7 +122,7 @@ The SCST target supports several fabric types. Must be one of "iscsi" or
 <content type="string" default="${OCF_RESKEY_fabric_default}"/>
 </parameter>
 
-<parameter name="target_id" required="1" unique="1">
+<parameter name="target_id" required="1" unique="0">
 <longdesc lang="en">
 A white-space separated list of targets this Logical Unit belongs to.
 For iSCSI targets this has to be the target iSCSI Qualified Name (IQN).
@@ -133,7 +133,7 @@ identification.
 <content type="string" />
 </parameter>
 
-<parameter name="lun" required="1" unique="1">
+<parameter name="lun" required="1" unique="0">
 <longdesc lang="en">
 The Logical Unit number (LUN) exposed to initiators.
 </longdesc>
@@ -141,7 +141,7 @@ The Logical Unit number (LUN) exposed to initiators.
 <content type="integer" />
 </parameter>
 
-<parameter name="path" required="1" unique="1">
+<parameter name="path" required="1" unique="0">
 <longdesc lang="en">
 The path to the block device or file to be exposed.
 </longdesc>
@@ -149,7 +149,7 @@ The path to the block device or file to be exposed.
 <content type="string" />
 </parameter>
 
-<parameter name="device_handler" required="0" unique="1">
+<parameter name="device_handler" required="0" unique="0">
 <longdesc lang="en">
 The SCST devive handler to be used for this Logical Unit.
 The supported handlers for this RA are:
@@ -159,7 +159,7 @@ vdisk_fileio, vdisk_blockio, vcdrom, vdisk_nullio
 <content type="string" default="${OCF_RESKEY_device_handler_default}"/>
 </parameter>
 
-<parameter name="scsi_id" required="0" unique="1">
+<parameter name="scsi_id" required="0" unique="0">
 <longdesc lang="en">
 The SCSI ID to be configured for this Logical Unit. The default
 is a hash of the resource name, truncated to 24 bytes.
@@ -168,7 +168,7 @@ is a hash of the resource name, truncated to 24 bytes.
 <content type="string" default="${OCF_RESKEY_scsi_id_default}"/>
 </parameter>
 
-<parameter name="scsi_sn" required="0" unique="1">
+<parameter name="scsi_sn" required="0" unique="0">
 <longdesc lang="en">
 The SCSI serial number to be configured for this Logical Unit.
 The default is a hash of the resource name, truncated
@@ -178,7 +178,7 @@ to 8 bytes.
 <content type="string" default="${OCF_RESKEY_scsi_sn_default}"/>
 </parameter>
 
-<parameter name="product_id" required="0" unique="1">
+<parameter name="product_id" required="0" unique="0">
 <longdesc lang="en">
 The SCSI product ID to be configured for this Logical Unit,
 truncated to 16 bytes.
@@ -187,7 +187,7 @@ truncated to 16 bytes.
 <content type="string" />
 </parameter>
 
-<parameter name="vendor_id" required="0" unique="1">
+<parameter name="vendor_id" required="0" unique="0">
 <longdesc lang="en">
 The SCSI vendor ID to be configured for this Logical Unit,
 truncated to 8 bytes.
@@ -196,7 +196,7 @@ truncated to 8 bytes.
 <content type="string" default="${OCF_RESKEY_vendor_id_default}"/>
 </parameter>
 
-<parameter name="vendor_specific_id" required="0" unique="1">
+<parameter name="vendor_specific_id" required="0" unique="0">
 <longdesc lang="en">
 The SCSI vendor specific ID to be configured for this Logical Unit.
 It defaults to the same value as the SCSI serial id, and is
@@ -206,7 +206,7 @@ truncated to 24 bytes.
 <content type="string" default="${OCF_RESKEY_scsi_id_default}"/>
 </parameter>
 
-<parameter name="additional_parameters" required="0" unique="1">
+<parameter name="additional_parameters" required="0" unique="0">
 <longdesc lang="en">
 Additional LU parameters. A space-separated list of "name=value" pairs
 which will be passed through to the targets management
@@ -241,7 +241,7 @@ implicitly using target-side configFS operations.
 <content type="string"/>
 </parameter>
 
-<parameter name="synchro_cs_vd_name" required="0" unique="1">
+<parameter name="synchro_cs_vd_name" required="0" unique="0">
 <longdesc lang="en">
 Name of a shared virtual drive, exported by a LSI/Avago Synchro CS
 controller. This name must be the one set for the block device

--- a/heartbeat/SCSTLogicalUnit
+++ b/heartbeat/SCSTLogicalUnit
@@ -580,19 +580,28 @@ SCSTLogicalUnit_acls() {
         # remove empty (or only exporting lun 0) ini_groups
         for initiator in $(find ${FABRIC_BASE}/${target}/ini_groups/ -mindepth 1 -maxdepth 1 -type d) ; do
             if [ $(find ${initiator}/luns -mindepth 1 -maxdepth 1 -type d ! -name '0' | wc -l) -eq 0 ] ; then
-                # Forcefully close all sessions.
-                # When using iSCSI MPIO, several sessions per initiator can be available.
-                for session in $(ls -1d ${FABRIC_BASE}/${target}/sessions/${initiator##*/} \
-                                        ${FABRIC_BASE}/${target}/sessions/${initiator##*/}_* 2>/dev/null) ; do
-                    scst_sysfs_write "1" "${session}/force_close" && \
-                    ocf_log warn "Forcefully closed session from initiator ${initiator##*/}."
-                done
+		#Redirect any new connections and loop until all connections have been closed
+		scst_sysfs_write "255.255.255.255:32600 temp" "${FABRIC_BASE}/${target}/redirect"
+                while [ -d ${FABRIC_BASE}/${target}/sessions/${initiator##*/} ];
+                do
+        	        # Forcefully close all sessions.
+	                # When using iSCSI MPIO, several sessions per initiator can be available.
+	                for session in $(ls -1d ${FABRIC_BASE}/${target}/sessions/${initiator##*/} \
+        	                                ${FABRIC_BASE}/${target}/sessions/${initiator##*/}_* 2>/dev/null) ; do
+                	    scst_sysfs_write "1" "${session}/force_close" && \
+                    	ocf_log warn "Forcefully closed session from initiator ${initiator##*/}."
+                	done
+		done
                 # Delete the ini_group
                 scst_sysfs_write "del ${initiator##*/}" ${FABRIC_BASE}/${target}/ini_groups/mgmt || {
                      ocf_log err "Unable to delete initiator group ${initiator##*/} from target ${target}.";
+		     #remove redirect
+		     scst_sysfs_write " " "${FABRIC_BASE}/${target}/redirect"
                      exit $OCF_ERR_GENERIC
                 }
                 ocf_log debug "${OCF_RESOURCE_INSTANCE}: Deleted empty initiator group ${initiator##*/} from target ${target}."
+		#Remove redirect
+		scst_sysfs_write " " "${FABRIC_BASE}/${target}/redirect"
            fi
         done
     done

--- a/heartbeat/SCSTLogicalUnit
+++ b/heartbeat/SCSTLogicalUnit
@@ -768,27 +768,29 @@ SCSTLogicalUnit_start() {
                 # apply "rel_tgt_id"s in a consistent way.
                 declare -a local_targets=( $(for target in $(${CRM_ATTR_GET_TGT} ${tpg}); do echo ${target};done | sort -bdf) )
                 for target in "${local_targets[@]}"; do
-                    # We need a unique rel_tgt_id for every port in the TPG,
-                    # also for multiple ports per node.
-                    rel_tgt_id=$(( ($(get_index ${tpg} "${tpgs[*]}") * 1000 ) + \
-                                   ($(get_index ${target} "${local_targets[*]}") + ${tpg_base} ) ))
-                    if [ -d "${dev_group}/target_groups/${tpg}" ]; then
-                        if [ ! -e "${dev_group}/target_groups/${tpg}/${target}" ]; then
-                            scst_sysfs_write "add ${target}" ${dev_group}/target_groups/${tpg}/mgmt || {
-                                ocf_log err "Unable to add target ${target} to TPG ${tpg} for device_group ${OCF_RESOURCE_INSTANCE}.";
-                                exit $OCF_ERR_GENERIC
-                            }
-                            ocf_log debug "${OCF_RESOURCE_INSTANCE}: Added target ${target} to TPG ${tpg} - device_group ${OCF_RESOURCE_INSTANCE}."
-                        fi
+					if [ ${HOSTNAME} == ${tpg} ]; then
+	                    # We need a unique rel_tgt_id for every port in the TPG,
+    	                # also for multiple ports per node.
+        	            rel_tgt_id=$(( ($(get_index ${tpg} "${tpgs[*]}") * 1000 ) + \
+            	                       ($(get_index ${target} "${local_targets[*]}") + ${tpg_base} ) ))
+                	    if [ -d "${dev_group}/target_groups/${tpg}" ]; then
+                    	    if [ ! -e "${dev_group}/target_groups/${tpg}/${target}" ]; then
+                        	    scst_sysfs_write "add ${target}" ${dev_group}/target_groups/${tpg}/mgmt || {
+                            	    ocf_log err "Unable to add target ${target} to TPG ${tpg} for device_group ${OCF_RESOURCE_INSTANCE}.";
+                            	   	exit $OCF_ERR_GENERIC
+                            	}
+                            	ocf_log debug "${OCF_RESOURCE_INSTANCE}: Added target ${target} to TPG ${tpg} - device_group ${OCF_RESOURCE_INSTANCE}."
+                        	fi
 
-                        if [ -d "${dev_group}/target_groups/${tpg}/${target}" ]; then
-                            scst_sysfs_write "${rel_tgt_id}" ${dev_group}/target_groups/${tpg}/${target}/rel_tgt_id || {
-                                ocf_log err "Unable to set relative target id ${rel_tgt_id} for target ${target} - device_group ${OCF_RESOURCE_INSTANCE}.";
-                                exit $OCF_ERR_GENERIC
-                            }
-                            ocf_log debug "${OCF_RESOURCE_INSTANCE}: Set rel_tgt_id ${rel_tgt_id} for target ${target} - TPG ${tpg}, device_group ${OCF_RESOURCE_INSTANCE}."
-                        fi
-                   fi
+                        	if [ -d "${dev_group}/target_groups/${tpg}/${target}" ]; then
+                            	scst_sysfs_write "${rel_tgt_id}" ${dev_group}/target_groups/${tpg}/${target}/rel_tgt_id || {
+                                	ocf_log err "Unable to set relative target id ${rel_tgt_id} for target ${target} - device_group ${OCF_RESOURCE_INSTANCE}.";
+                                	exit $OCF_ERR_GENERIC
+                            	}
+                            	ocf_log debug "${OCF_RESOURCE_INSTANCE}: Set rel_tgt_id ${rel_tgt_id} for target ${target} - TPG ${tpg}, device_group ${OCF_RESOURCE_INSTANCE}."
+                        	fi
+                   		fi
+					fi
                 done
             fi
         done

--- a/heartbeat/SCSTTarget
+++ b/heartbeat/SCSTTarget
@@ -78,7 +78,7 @@ Manages SCST targets. A target is a daemon that speaks
 <shortdesc lang="en">SCST target export agent</shortdesc>
 
 <parameters>
-<parameter name="fabric" required="0" unique="1">
+<parameter name="fabric" required="0" unique="0">
 <longdesc lang="en">
 The SCST target supports several fabric types. Must be one of "iscsi" or
 "qla2x00t". If unspecified, "iscsi" is used.
@@ -87,7 +87,7 @@ The SCST target supports several fabric types. Must be one of "iscsi" or
 <content type="string" default="${OCF_RESKEY_fabric_default}"/>
 </parameter>
 
-<parameter name="id" required="1" unique="1">
+<parameter name="id" required="1" unique="0">
 <longdesc lang="en">
 ISCSI targets use an iSCSI Qualified Name (IQN). Should follow the conventional
 "iqn.yyyy-mm.&lt;reversed domain name&gt;[:identifier]" syntax.


### PR DESCRIPTION
Thanks for creating these RA's, after a few modifications they seem to be working really well.
1. The unique parameters seem to cause an infinite loop of restarts. As soon as I set them to unique=0 everything stopped looping. The Target script loop was triggered when the attribute for local IQN's was set and the LU script loop was triggered by updating the master score. 
2. I noticed the the ALUA states where not getting correctly set on slaves, this was partly down to the IF statement setting rather than comparing
3. About 1/3 of the time, when placing a node into standby, the LU resource would fail because it couldn't delete the initiator group. I added a SCST connection redirect and a loop to make sure all sessions are definitely dead and can't restart until the group has been deleted.
4. I was getting a "File exists" error back from sysfs when adding the IQN targets to the TPG's. As far as I am aware the Target is only meant to exist on the local TPG.
